### PR TITLE
Added setup.py to fix setup error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
pip install -e .
Obtaining file:///home/user/Janus
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
ERROR: Project file:///home/user/Janus has a 'pyproject.toml' and its build backend is missing the 'build_editable' hook. Since it does not have a 'setup.py' nor a 'setup.cfg', it cannot be installed in editable mode. Consider using a build backend that supports PEP 660.