### PR TITLE
Bump SentencePiece to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ gradio = [
     "colorama==0.4.5",
     "Pygments==2.12.0",
     "markdown==3.4.1",
-    "SentencePiece==0.1.96"
+    "SentencePiece==0.2.0"
 ]
 lint = [
     "isort",


### PR DESCRIPTION
This version has binary wheels for arm64 macOS. 

Otherwise building SentencePiece wheel on Catalina is problematic due to them using implicit conversions disallowed in safemode libc++:

```
src/sentencepiece/sentencepiece_wrap.cxx:3658:38: error: no viable conversion from 'const vector<std::string>' to 'const vector<absl::string_view>
```