### PR TITLE
Remove duplicate SentencePiece package declaration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ torch==2.0.1
 transformers>=4.38.2
 timm>=0.9.16
 accelerate
-sentencepiece
 attrdict
 einops
 


### PR DESCRIPTION
Description:
This PR addresses a redundancy in the requirements.txt file by removing the duplicate declaration of the SentencePiece package. Currently, the package is listed twice:
- As `sentencepiece` (lowercase, no version specified)
- As `SentencePiece==0.1.96` (with specific version)

Changes made:
- Removed the unversioned `sentencepiece` entry
- Retained `SentencePiece==0.1.96` for version consistency

Rationale:
- Python packages are case-insensitive, making these entries effectively duplicate
- Keeping the versioned dependency ensures reproducible builds
- This change maintains project stability while cleaning up the dependency list

Testing:
- Verified that the project builds successfully with the updated requirements.txt
- Confirmed all dependent functionality remains intact

Please review and merge if appropriate.