### PR TITLE
Fix README.md to show QuickStart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ permitted under these terms.
 
 
 ## 3. Quick Start
-<details>
-<summary><h3>Janus-Pro</h3></summary>
+
 
 ### Installation
 
@@ -708,7 +707,6 @@ python demo/app_janusflow.py
 
 Have Fun!
     
-</details>
 
 ## 4. License
 


### PR DESCRIPTION
Hi,

Currently, the QuickStart section doesn't render properly in a browser because of remaining xml tags: <details> and <summary> don't render properly in Chrome and hive the full set of instructions

Removing them makes the QuickStart section visible and clean

Didier